### PR TITLE
Adds property alignsTextToTop which disables scrolls to bottom

### DIFF
--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -79,7 +79,7 @@ public class NextGrowingTextView: UIScrollView {
         }
     }
     
-    public var alignsTextToTop = false
+    public var disableAutomaticScrollToBottom = false
     
     public override init(frame: CGRect) {
         let textView = NextGrowingInternalTextView(frame: CGRect(origin: CGPoint.zero, size: frame.size))
@@ -210,7 +210,7 @@ public class NextGrowingTextView: UIScrollView {
     }
     
     private func scrollToBottom() {
-        if !alignsTextToTop {
+        if !disableAutomaticScrollToBottom {
             let offset = self.contentOffset
             self.contentOffset = CGPoint(x: offset.x, y: self.contentSize.height - self.frame.height)
         }

--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -79,6 +79,8 @@ public class NextGrowingTextView: UIScrollView {
         }
     }
     
+    public var alignsTextToTop = false
+    
     public override init(frame: CGRect) {
         let textView = NextGrowingInternalTextView(frame: CGRect(origin: CGPoint.zero, size: frame.size))
         self.textView = textView
@@ -208,8 +210,10 @@ public class NextGrowingTextView: UIScrollView {
     }
     
     private func scrollToBottom() {
-        let offset = self.contentOffset
-        self.contentOffset = CGPoint(x: offset.x, y: self.contentSize.height - self.frame.height)
+        if !alignsTextToTop {
+            let offset = self.contentOffset
+            self.contentOffset = CGPoint(x: offset.x, y: self.contentSize.height - self.frame.height)
+        }
     }
     
     private func simulateHeight(line: Int) -> CGFloat {


### PR DESCRIPTION
When you have a text view which expands downwards, you enter a couple of lines and remove them, the text will be "aligned" to the bottom as the text view scrolls to the bottom. I have added a property `alignsTextToTop` which disables this behaviour and keeps the text at the top.