### PR TITLE
updated .podspec file for beta release of cocoapods.

### DIFF
--- a/NextGrowingTextView.podspec
+++ b/NextGrowingTextView.podspec
@@ -20,7 +20,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Pod/Classes/**/*'
-  s.resource_bundles = {
-    'NextGrowingTextView' => ['Pod/Assets/*.png']
-  }
+
 end


### PR DESCRIPTION
While building project, XCode gives an error called "resource.bundle was not found". This is typically happening when you type either `pod install` or `pod update` after dependency added to podfile. Therefore, I updated .podspec file and removed line stated as project resources. Because, project does not have any asset catalog or file. 

I've searched and found that this is only happening in 1.0.0 beta 6. On the other hand, this is a known [issue](https://github.com/CocoaPods/CocoaPods/issues/5034) in Cocoapods with the same version.
