### PR TITLE
Fixed infinite recursion crash when custom typingAttributes are used

### DIFF
--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -313,8 +313,8 @@ extension NextGrowingTextView {
     }
 
     public var typingAttributes: [String : AnyObject] {
-        get { return self.typingAttributes }
-        set { self.typingAttributes = newValue }
+        get { return self.textView.typingAttributes }
+        set { self.textView.typingAttributes = newValue }
     }
 
     public func scrollRangeToVisible(range: NSRange) {


### PR DESCRIPTION
Hi,
thanks for the a great component.

This PR fixes EXC_BAD_ACCESS infinite recursion crash when using custom `typingAttributes`. Pretty simple and obvious :-)

![screen shot 2016-04-28 at 13 05 13](https://cloud.githubusercontent.com/assets/2315799/14884034/7f4c0e6c-0d42-11e6-8b52-25c9df973a66.png)

