### PR TITLE
Fix height calculation taking textContainerInset into account

### DIFF
--- a/Example/NextGrowingTextView/ViewController.swift
+++ b/Example/NextGrowingTextView/ViewController.swift
@@ -39,6 +39,12 @@ class ViewController: UIViewController {
         
         self.growingTextView.layer.cornerRadius = 4
         self.growingTextView.backgroundColor = UIColor(white: 0.9, alpha: 1)
+        self.growingTextView.textContainerInset = UIEdgeInsets(top: 16, left: 0, bottom: 4, right: 0)
+        self.growingTextView.placeholderAttributedText = NSAttributedString(string: "Placeholder text",
+                                                                            attributes: [NSFontAttributeName: self.growingTextView.font!,
+                                                                                         NSForegroundColorAttributeName: UIColor.grayColor()
+            ]
+        )
     }
     
     override func didReceiveMemoryWarning() {

--- a/Pod/Classes/NextGrowingInternalTextView.swift
+++ b/Pod/Classes/NextGrowingInternalTextView.swift
@@ -71,7 +71,10 @@ internal class NextGrowingInternalTextView: UITextView {
         let paragraphStyle: NSMutableParagraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = self.textAlignment
         
-        let targetRect = CGRect(x: 5, y: 8 + self.contentInset.top, width: self.frame.size.width - self.contentInset.left, height: self.frame.size.height - self.contentInset.top)
+        let targetRect = CGRect(x: 5 + self.textContainerInset.left,
+                                y: self.textContainerInset.top,
+                                width: self.frame.size.width - (self.textContainerInset.left + self.textContainerInset.right),
+                                height: self.frame.size.height - (self.textContainerInset.top + self.textContainerInset.bottom))
         
         let attributedString = self.placeholderAttributedText
         attributedString?.drawInRect(targetRect)

--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -154,7 +154,7 @@ public class NextGrowingTextView: UIScrollView {
         self.textView.font = UIFont.systemFontOfSize(16)
         self.textView.backgroundColor = UIColor.clearColor()
         self.addSubview(textView)
-        self.minHeight = frame.height
+        self.minHeight = simulateHeight(0)
         self.maxNumberOfLines = 3
     }
 
@@ -214,6 +214,12 @@ public class NextGrowingTextView: UIScrollView {
             self.contentOffset = CGPoint(x: offset.x, y: self.contentSize.height - self.frame.height)
         }
     }
+    
+    private func updateMinimumAndMaximumHeight() {
+        self.minHeight = simulateHeight(0)
+        self.maxHeight = simulateHeight(self.maxNumberOfLines)
+        self.fitToScrollView()
+    }
 
     private func simulateHeight(line: Int) -> CGFloat {
 
@@ -229,8 +235,7 @@ public class NextGrowingTextView: UIScrollView {
 
         self.textView.text = newText
 
-        let textViewMargin: CGFloat = 16
-        let height = self.measureTextViewSize().height - (textViewMargin + self.textView.contentInset.top + self.textView.contentInset.bottom)
+        let height = self.measureTextViewSize().height
 
         self.textView.text = saveText
         self.textView.hidden = false
@@ -271,7 +276,10 @@ extension NextGrowingTextView {
 
     public var font: UIFont? {
         get { return self.textView.font }
-        set { self.textView.font = newValue }
+        set {
+            self.textView.font = newValue
+            self.updateMinimumAndMaximumHeight()
+        }
     }
 
     public var textColor: UIColor? {
@@ -342,7 +350,10 @@ extension NextGrowingTextView {
 
     public var textContainerInset: UIEdgeInsets {
         get { return self.textView.textContainerInset }
-        set { self.textView.textContainerInset = newValue }
+        set {
+            self.textView.textContainerInset = newValue
+            self.updateMinimumAndMaximumHeight()
+        }
     }
 
     public var layoutManger: NSLayoutManager {


### PR DESCRIPTION
This pull request fixes the height calculation when the user changes the `textView`'s  `textContentInset`, which by default is `{top: 8, left: 0, bottom: 8, right: 0}`. It includes the following changes:

- Example code to demonstrate the fixed functionality: you can change the `textContainerInset` and run the example app to see how it changes the appearance of the text field.
- Fixes the calculation of the frame used to draw the placeholder.
- Uses the `textContainerInset` to calculate the minimum and maximum frame of the text field. Before `contentInset` was used, but this property is not exposed to the outside and by default it's `UIEdgeInsetsZero`
- Sets the initial height of the `textField` to be the one we need to display a minimum text, and not the one we define when creating the view, either via `-initWithFrame:` or `-initWithCoder:` (from Interface builder). 