### PR TITLE
Fix endless recursion setting the attributed text

### DIFF
--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -315,7 +315,7 @@ extension NextGrowingTextView {
     public var attributedText: NSAttributedString! {
         get { return self.textView.attributedText }
         set {
-            self.attributedText = newValue
+            self.textView.attributedText = newValue
             self.fitToScrollView()
         }
     }


### PR DESCRIPTION
Setting the attributedText in the setter itself invokes a endless recursion. This should fix that.