### PR TITLE
Added support for reloadInputViews()

### DIFF
--- a/Pod/Classes/NextGrowingTextView.swift
+++ b/Pod/Classes/NextGrowingTextView.swift
@@ -137,6 +137,10 @@ public class NextGrowingTextView: UIScrollView {
     public override func intrinsicContentSize() -> CGSize {
         return self.measureFrame(self.measureTextViewSize()).size
     }
+    
+    public override func reloadInputViews() {
+        return self.textView.reloadInputViews()
+    }
 
     // MARK: Private
 


### PR DESCRIPTION
Hey muukii,
me again :-)

I have added proxy method for `reloadInputViews()`. It is crucial if you need to change `keyboardType` (my previous PR) while the `UITextView` is first responder. In that case you have to explicitly call `reloadInputViews()` so the keyboard UI is updated.

Example (to be put to Example/ViewController.swift):

```swift
override func viewWillAppear(animated: Bool) {
    super.viewWillAppear(animated)
    
    self.growingTextView.becomeFirstResponder()
    
    let delayTime = dispatch_time(DISPATCH_TIME_NOW, Int64(2 * Double(NSEC_PER_SEC)))
    dispatch_after(delayTime, dispatch_get_main_queue()) { [weak self] in
        self?.growingTextView.keyboardType = .DecimalPad
        self?.growingTextView.reloadInputViews()
    }
}
```