### PR TITLE
Bring back keyboardType

### DIFF
--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -336,6 +336,11 @@ extension NextGrowingTextView {
         get { return textView.inputView }
         set { textView.inputView = newValue }
     }
+    
+    public var keyboardType: UIKeyboardType {
+        get { return textView.keyboardType }
+        set { textView.keyboardType = newValue }
+    }
 
     public var textViewInputAccessoryView: UIView? {
         get { return textView.inputAccessoryView }

--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -323,8 +323,8 @@ extension NextGrowingTextView {
         }
     }
 
-    public var typingAttributes: [String : AnyObject] {
-        get { return self.textView.typingAttributes as [String : AnyObject] }
+    public var typingAttributes: [String : Any] {
+        get { return self.textView.typingAttributes }
         set { self.textView.typingAttributes = newValue }
     }
 
@@ -372,8 +372,8 @@ extension NextGrowingTextView {
         return textView.textStorage
     }
 
-    public var linkTextAttributes: [String : AnyObject]! {
-        get { return self.textView.linkTextAttributes as [String : AnyObject]! }
+    public var linkTextAttributes: [String : Any]! {
+        get { return self.textView.linkTextAttributes}
         set { self.textView.linkTextAttributes = newValue }
     }
 }


### PR DESCRIPTION
After the conversion to Swift 3, the keyboardType property somehow disappeared. This PR just brings it back.

If you want, I can also do the preparation needed to bump the version to 0.8.2.

Best regards! 