### PR TITLE
Fix min height calculation when change `font` and `textContainerInset`

### DIFF
--- a/NextGrowingTextView/NextGrowingInternalTextView.swift
+++ b/NextGrowingTextView/NextGrowingInternalTextView.swift
@@ -30,6 +30,7 @@ internal class NextGrowingInternalTextView: UITextView {
   // MARK: - Internal
 
   var didChange: () -> Void = {}
+  var didUpdateHeightDependencies: () -> Void = {}
 
   override init(frame: CGRect, textContainer: NSTextContainer?) {
     super.init(frame: frame, textContainer: textContainer)
@@ -56,6 +57,18 @@ internal class NextGrowingInternalTextView: UITextView {
     didSet {
       didChange()
       updatePlaceholder()
+    }
+  }
+    
+  override var font: UIFont? {
+    didSet {
+      didUpdateHeightDependencies()
+    }
+  }
+    
+  override var textContainerInset: UIEdgeInsets {
+    didSet {
+      didUpdateHeightDependencies()
     }
   }
 

--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -162,6 +162,9 @@ open class NextGrowingTextView: UIScrollView {
     _textView.didChange = { [weak self] in
       self?.fitToScrollView()
     }
+    _textView.didUpdateHeightDependencies = { [weak self] in
+      self?.updateMinimumAndMaximumHeight()
+    }
   }
 
   private func measureTextViewSize() -> CGSize {


### PR DESCRIPTION
Now `updateMinimumAndMaximumHeight()` is never used. And `_minHeight` updates only in `setup()` and `minNumberOfLines` setter.  So if change font or insets of textView, `_minHeight` will be still unchanged, and future calculations of height will be incorrect.
In this PR i added new closure, that will be called when `font` or `textContainerInset` changed. With this fix, height calculated correctly