### PR TITLE
Flash scroll indicators depends on isFlashScrollIndicatorsEnabled value

### DIFF
--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -72,6 +72,8 @@ open class NextGrowingTextView: UIScrollView {
   }
 
   open var isAutomaticScrollToBottomEnabled = true
+
+  /// Use this to enable/disable flash scroll indicators while scroll height is less than max height
   open var isFlashScrollIndicatorsEnabled = true
   
   open var placeholderAttributedText: NSAttributedString? {

--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -74,7 +74,7 @@ open class NextGrowingTextView: UIScrollView {
   open var isAutomaticScrollToBottomEnabled = true
 
   /// Use this to enable/disable flash scroll indicators while scroll height is less than max height
-  open var isFlashScrollIndicatorsEnabled = true
+  public var isFlashScrollIndicatorsEnabled = true
   
   open var placeholderAttributedText: NSAttributedString? {
     get { return _textView.placeholderAttributedText }

--- a/NextGrowingTextView/NextGrowingTextView.swift
+++ b/NextGrowingTextView/NextGrowingTextView.swift
@@ -72,6 +72,7 @@ open class NextGrowingTextView: UIScrollView {
   }
 
   open var isAutomaticScrollToBottomEnabled = true
+  open var isFlashScrollIndicatorsEnabled = true
   
   open var placeholderAttributedText: NSAttributedString? {
     get { return _textView.placeholderAttributedText }
@@ -215,7 +216,7 @@ open class NextGrowingTextView: UIScrollView {
     let newScrollViewFrame = measureFrame(actualTextViewSize)
 
     if oldScrollViewFrame.height != newScrollViewFrame.height && newScrollViewFrame.height <= _maxHeight {
-      flashScrollIndicators()
+      isFlashScrollIndicatorsEnabled ? flashScrollIndicators() : ()
       delegates.willChangeHeight(newScrollViewFrame.height)
     }
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ public var delegates: Delegates
 public override init(frame: CGRect)
 ```
 
+Use `isFlashScrollIndicatorsEnabled` to enable/disable flash scroll indicators while text view height is less than max height.
+
 ## Delegates
 
 ```


### PR DESCRIPTION
- Some users don't need to flash scroll indicators while scroll view height is less than max height. isFlashScrollIndicatorsEnabled variable is declared open to be accessible.
- add isFlashScrollIndicatorsEnabled description on README.md 