### PR TITLE
Build fails when building with Xcode 10 or earlier

### DIFF
--- a/NextGrowingTextView/NextGrowingInternalTextView.swift
+++ b/NextGrowingTextView/NextGrowingInternalTextView.swift
@@ -81,7 +81,11 @@ internal class NextGrowingInternalTextView: UITextView {
   
   var placeholderAttributedText: NSAttributedString? {
     get {
-      placeholderDisplayLabel.attributedText
+      #if swift(>=5.1)
+        placeholderDisplayLabel.attributedText
+      #else
+        return placeholderDisplayLabel.attributedText
+      #endif
     }
     set {
       placeholderDisplayLabel.attributedText = newValue


### PR DESCRIPTION
Hi, muukii. Thank you for your amazing works!

I'm using Xcode10(swift 5.0), and your library with Carthage.

When building NextGrowingTextView with swift 5.0(Xcode 10), compile error occurs as below.
```
/_PATH_TO_PROJECT_/Carthage/Checkouts/NextGrowingTextView/NextGrowingTextView/NextGrowingInternalTextView.swift:84:31: error: expression resolves to an unused property
      placeholderDisplayLabel.attributedText
      ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~
```

I think this error is caused by new syntax of swift 5.1, so I added conditional branch with swift version.
If there is no problem, please pull this request. 