### PR TITLE
Fix a warning in Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,6 @@ let package = Package(
         .library(name: "NextGrowingTextView", targets: ["NextGrowingTextView"]),
     ],
     targets: [     
-        .target(name: "NextGrowingTextView", path: "NextGrowingTextView", exclude: ["NextGrowingTextView/Info.plist"]),
+        .target(name: "NextGrowingTextView", path: "NextGrowingTextView"),
     ]
 )


### PR DESCRIPTION
Changed the setting because the following error is displayed.

```
Invalid Exclude 'ProjectDirectory/SourcePackages/checkouts/NextGrowingTextView/NextGrowingTextView/NextGrowingTextView/Info.plist': File not found.
```